### PR TITLE
Fix for #212

### DIFF
--- a/crm/libraries/Blossom/Classes/View.php
+++ b/crm/libraries/Blossom/Classes/View.php
@@ -36,6 +36,7 @@ abstract class View
 				APPLICATION_HOME.'/language',
 				'%s.mo'
 			);
+			self::$translator->setLocale(LOCALE);
 		}
 	}
 


### PR DESCRIPTION
With this fix, setting LOCALE to nl_NL will parse nl_NL.mo and show the application in the dutch translation.