### PR TITLE
CICD: Add unit tests to pipeline

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,14 +1,34 @@
 name: uReport CICD
 
-on: [ push, pull_request ]
+on: 
+  push:
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_NAME: ureport
+      DB_USER: ureport
+      DB_PASS: ureport
+
+    services:
+      db:
+        image: mariadb:10.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: ureport
+          MYSQL_USER: ureport
+          MYSQL_PASSWORD: ureport
+        ports:
+          - 3306:3306
 
     steps:
     - name: Checkout code
@@ -17,17 +37,12 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.3'
-
-    - name: Debug PHP
-      run: |
-        which php
-        php -v
+        php-version: '8.5'
 
     - name: Validate composer.json
       run: composer validate --no-check-lock --working-dir=crm
 
-    - name: Cache Composer packages
+    - name: Cache Composer Packages
       id: composer-cache
       uses: actions/cache@v3
       with:
@@ -36,7 +51,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-php-
 
-    - name: Install dependencies
+    - name: Install Dependencies
       run: composer install --prefer-dist --no-progress --ignore-platform-reqs --working-dir=crm
 
     - name: PHP Lint
@@ -52,3 +67,33 @@ jobs:
             echo "Linting: $file"
             php -l "$file" > /dev/null
         done
+
+    - name: Site Configuration Setup
+      run: |
+        mkdir -p crm/src/Test/data
+        cp infra/site_config.test.php crm/src/Test/data/site_config.php
+
+    - name: Wait for database
+      run: ./infra/wait-for-db.sh
+
+    - name: Import schema
+      run: |
+        mysql \
+          -h"$DB_HOST" \
+          -P"$DB_PORT" \
+          -u"$DB_USER" \
+          -p"$DB_PASS" \
+          "$DB_NAME" < crm/scripts/mysql.sql
+
+    - name: Import seed data
+      run: |
+        mysql \
+          -h"$DB_HOST" \
+          -P"$DB_PORT" \
+          -u"$DB_USER" \
+          -p"$DB_PASS" \
+          "$DB_NAME" < infra/seed.sql
+
+    - name: Unit Tests
+      working-directory: ./crm
+      run: vendor/bin/phpunit -c src/Test/phpunit.xml --testsuite Unit

--- a/infra/docker-setup.sh
+++ b/infra/docker-setup.sh
@@ -2,11 +2,6 @@
 set -e
 
 # --- Configuration ---
-# MySQL
-DB_HOST="${DB_HOST:-db}"
-DB_PORT="${DB_PORT:-3306}"
-DB_USER="${DB_USER:-ureport}"
-DB_PASS="${DB_PASS:-ureport}"
 
 # Solr
 SOLR_HOST="${SOLR_HOST:-solr}"
@@ -29,16 +24,7 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 
 # --- Wait for MySQL ---
-echo "Waiting for MySQL at $DB_HOST:$DB_PORT..."
-until mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" --ssl=0 -e "SELECT 1"; do
-    if [ $SECONDS -ge $TIMEOUT ]; then
-        echo "Timeout waiting for MySQL"
-        exit 1
-    fi
-    echo "MySQL not ready yet... sleeping 2s"
-    sleep 2
-done
-echo "MySQL is ready!"
+./infra/wait-for-db.sh
 
 # --- Wait for Solr ---
 echo "Waiting for Solr core '$SOLR_CORE' at $SOLR_HOST:$SOLR_PORT..."

--- a/infra/site_config.test.php
+++ b/infra/site_config.test.php
@@ -1,0 +1,120 @@
+<?php
+define('APPLICATION_NAME','CRM');
+
+/**
+ * URL Generation settings
+ *
+ * Do NOT use trailing slashes
+ *
+ * If your site is being proxied, change BASE_HOST to the hostname
+ * used for the outside world.
+ */
+define('BASE_URI' , '');
+define('BASE_HOST', 'localhost:8080');
+define('BASE_URL' , 'http://localhost:8080');
+
+/**
+ * Specify the theme directory
+ *
+ * Remember to create a symbolic link in public/css to the theme CSS
+ * that you declare here.
+ *
+ * A theme can consist of templates, blocks which will override core.
+ * The current theme's screen.css will be included in the HTML head.
+ */
+define('THEME', 'COB');
+
+/**
+ * JavaScript Libraries
+ */
+define('GOOGLE_MAPS',   'http://maps.googleapis.com/maps/api/js?sensor=false');
+define('GOOGLE_LOADER', 'http://www.google.com/jsapi');
+
+/**
+ * Database Setup
+ */
+$DATABASES = [
+    'default' => [
+        'dsn'     =>sprintf(
+            'mysql:host=%s;port=%s;dbname=%s',
+            getenv('DB_HOST'),
+            getenv('DB_PORT'),
+            getenv('DB_NAME')),
+        'user'    => getenv('DB_USER'),
+        'pass'    => getenv('DB_PASS'),
+        'options' => []
+    ]
+];
+
+$AUTHENTICATION = [
+    'oidc' => [
+        'server'         => 'https://ad.example.org/adfs',
+        'client_id'      => '',
+        'client_secret'  => '',
+        'claims' => [
+            // OnBoard field => OIDC Claim
+            'username'    => 'adfs1upn',
+            'displayname' => 'commonname',
+            'firstname'   => 'given_name',
+            'lastname'    => 'family_name',
+            'email'       => 'upn',
+            'groups'      => 'group',
+            'groupmap'    => [ ]
+        ],
+    ]
+];
+
+/**
+ * Controls whether the system sends email notifications to people
+ */
+define('NOTIFICATIONS_ENABLED', true);
+define('SMTP_HOST', 'localhost.localdomain');
+define('SMTP_PORT', 25);
+define('ADMINISTRATOR_EMAIL', 'someone@localhost');
+
+/**
+ * Point to the Solr server
+ */
+$SOLR = [
+    'ureport' => [
+        'scheme'   => 'https',
+        'host'     => 'localhost',
+        'port'     => 443,
+        'core'     => 'ureport',
+        'username' => 'ureport',
+        'password' => 'secret password'
+    ]
+];
+
+/**
+ * Some default values for Tickets in the system
+ */
+define('DEFAULT_CITY','Bloomington');
+define('DEFAULT_STATE','IN');
+
+/**
+ * Default coordinates for map center
+ * This should probably be the center of your city
+ * If you can, it's best to adjust these values in your php.ini
+ */
+define('DEFAULT_LATITUDE', ini_get('date.default_latitude'));
+define('DEFAULT_LONGITUDE',ini_get('date.default_longitude'));
+
+/**
+ * This is a unique string identifying your jurisdiction to the
+ * rest of the Open311 community.
+ *
+ * Open311 servers typically use their domain name as their jurisdiction
+ */
+define('OPEN311_JURISDICTION','localhost');
+define('OPEN311_KEY_SERVICE', 'http://localhost/open311-api-key-request');
+
+define('THUMBNAIL_SIZE', 150);
+
+define('CLOSING_COMMENT_REQUIRED_LENGTH', 1);
+define('AUTO_CLOSE_COMMENT', 'Closed automatically');
+
+define('DATE_FORMAT', 'n/j/Y');
+define('DATETIME_FORMAT', 'n/j/Y H:i:s');
+define('TIME_FORMAT', 'H:i:s');
+define('LOCALE', 'en_US');

--- a/infra/wait-for-db.sh
+++ b/infra/wait-for-db.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_HOST="${DB_HOST:-db}"
+DB_PORT="${DB_PORT:-3306}"
+DB_NAME="${DB_NAME:-ureport}"
+DB_USER="${DB_USER:-ureport}"
+DB_PASS="${DB_PASS:-ureport}"
+
+TIMEOUT="${DB_WAIT_TIMEOUT:-60}"
+START=$(date +%s)
+
+echo "Waiting for MySQL at ${DB_HOST}:${DB_PORT}..."
+
+MYSQL_VERSION="$(mysql --version)"
+
+if echo "${MYSQL_VERSION}" | grep -qi mariadb; then
+    SSL_FLAG="--skip-ssl"
+else
+    SSL_FLAG="--ssl-mode=DISABLED"
+fi
+
+until mysql \
+    -h"${DB_HOST}" \
+    -P"${DB_PORT}" \
+    -u"${DB_USER}" \
+    -p"${DB_PASS}" \
+    "${DB_NAME}" \
+    ${SSL_FLAG} -e "SELECT 1";
+do
+    NOW=$(date +%s)
+
+    if [ $((NOW - START)) -ge "${TIMEOUT}" ]; then
+        echo "Timed out waiting for MySQL database"
+        exit 1
+    fi
+    echo "MySQL not ready yet... sleeping 2s"
+    sleep 2
+done
+
+echo "MySQL is ready!"


### PR DESCRIPTION
This PR configures the CI pipeline to set up a minimal test database and run all unit tests against each push and pull request. As discussed in another thread we should eventually rewrite these tests to utilize a transactional approach, spinning up an isolated, in-memory database for each test case that is spun down after the test is completed.