### PR TITLE
CICD: Add PHPStan to CI pipeline

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -73,6 +73,10 @@ jobs:
         mkdir -p crm/src/Test/data
         cp infra/site_config.test.php crm/src/Test/data/site_config.php
 
+    - name: PHP Stan
+      working-directory: ./crm
+      run: vendor/bin/phpstan analyse -l 5 --memory-limit 1G
+
     - name: Wait for database
       run: ./infra/wait-for-db.sh
 

--- a/crm/phpstan.neon
+++ b/crm/phpstan.neon
@@ -6,6 +6,11 @@ parameters:
     - Application\Template
     - Application\View
     - Application\Url
+    - Solarium\Core\Query\DocumentInterface
+  dynamicConstantNames:
+    NOTIFICATIONS_ENABLED: bool
+    GRAYLOG_DOMAIN:        string
+    ADDRESS_SERVICE:       string
   paths:
     - src/Application
     - src/Domain

--- a/crm/src/Application/View.php
+++ b/crm/src/Application/View.php
@@ -25,7 +25,10 @@ abstract class View
                 $this->theme = $dir;
                 $config_file = $dir.'/theme_config.inc';
 
-                if (is_file($config_file)) { $this->theme_config = require $config_file; }
+                if (is_file($config_file)) { 
+                    // @phpstan-ignore require.fileNotFound
+                    $this->theme_config = require $config_file; 
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds PHPStan level 5 to the CI pipeline. There were a few things that PHPStan complained about, notably optionally defined constants and theme `require` statements. I went ahead and ignored those errors inline - if they become more widespread we can look into setting up a broader exclusion.