### PR TITLE
Fix wrapping for expanded notification text

### DIFF
--- a/crm/data/Themes/COB/public/css/screen.scss
+++ b/crm/data/Themes/COB/public/css/screen.scss
@@ -160,7 +160,10 @@ a.current { border:2px solid $color-calltoaction-background; }
     padding-left:1rem;
 
     h1 { font-size:$font-size-normal; }
-    .sentNotification .message { white-space: pre; }
+    .sentNotification .message {
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+    }
 }
 
 #location_map { margin-top:$size-gutter; }


### PR DESCRIPTION
Fixes #302.

Expanded sent notification messages were using white-space: pre, which keeps long lines on one line when the details panel is open. This switches to pre-wrap and adds overflow-wrap: anywhere so long messages wrap and stay readable.